### PR TITLE
Fix attach_to_email_tbird.nemo_action

### DIFF
--- a/.local/share/nemo/actions/attach_to_email_tbird.nemo_action
+++ b/.local/share/nemo/actions/attach_to_email_tbird.nemo_action
@@ -7,3 +7,4 @@ Selection=notnone
 Extensions=nodirs
 Separator=,
 Dependencies=thunderbird;
+EscapeSpaces=false


### PR DESCRIPTION
As the attached files are within ' ' already, do no escape spaces.